### PR TITLE
Added filtering database reference by ID

### DIFF
--- a/src/nesting/ieee8021q/relay/FilteringDatabase.cc
+++ b/src/nesting/ieee8021q/relay/FilteringDatabase.cc
@@ -59,14 +59,15 @@ int FilteringDatabase::numInitStages() const {
 void FilteringDatabase::loadDatabase(cXMLElement* xml, int cycle) {
     newCycle = cycle;
 
-    std::string switchName =
-            this->getModuleByPath(par("switchModule"))->getFullName();
+    std::string switchName = this->getModuleByPath(par("switchModule"))->getFullName();
+    std::string switchId = std::to_string(this->getModuleByPath(par("switchModule"))->getId());
     cXMLElement* fdb;
     //TODO this bool can probably be refactored to a nullptr check
     bool databaseFound = false;
     //try to extract the part of the filteringDatabase xml belonging to this module
     for (cXMLElement* host : xml->getChildren()) {
-        if (host->hasAttributes() && host->getAttribute("id") == switchName) {
+        //check for a matching switch name or id
+        if (host->hasAttributes() && (host->getAttribute("id") == switchName || host->getAttribute("id") == switchId)) {
             fdb = host;
             databaseFound = true;
             break;


### PR DESCRIPTION
First off, thank you so much for your contribution!

Added a minor adjustment to FilteringDatabse.cc to accept Switch ID references instead of their names exclusively, that way it can support topologies with Module arrays.
i.e if the NED file contains a `switch[SOME_COUNT]: VlanEtherSwitchPreemptable`, it cannot be referred to by its name (at least not in a straightforward manner). With the ID, however, the XML could just refer to each switch with its assigned ID, which can be easily found in the simulation window.

Tested on the provided example project with switch IDs = "2" and "3" instead of "switchA" and "switchB" (respectively) in `TestScenarioRouting.xml`